### PR TITLE
Add initial default CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Current Presto committers:
 | Rongrong Zhong    |[rongrong](https://github.com/rongrong)            | Facebook    |
 | Shixuan Fan       |[shixuan-fan](https://github.com/shixuan-fan)      | Facebook    |
 | Jiexi Lin         |[jessesleeping](https://github.com/jessesleeping)  | Facebook    |
+| Leiqing Cai       |[caithagoras](https://github.com/caithagoras)      | Facebook    |
 
 The path to committership starts with becoming a contributor to the project. Over time, contributors can prove that they have high commitment to the project.  Top contributors may become committers through either a simple majority vote by the existing committers, or by a 2/3 vote of the TSC.  An existing committer may be removed in the same manner.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,34 @@ All Presto development occurs on [GitHub](https://github.com/prestodb), followin
 
 Presto follows industry best practices, with the technical project and its governance distinctly separate from the Presto Foundation. The [Technical Charter](https://github.com/prestodb/tsc/blob/master/CHARTER.md) establishes the Presto Technical Steering Committee as the body which oversees all technical aspects of the open source project. By contrast, the [Presto Foundation](https://prestodb.io) Governing Board is responsible for raising and distributing funds to support project activities, and setting policy. While the two groups are separate, they work in close coordination to establish, guide, and support activities that lead to a long-term, sustainable future for Presto.
 
-### Project roles and responsibilities
-
-#### Contributors
+### Contributors
 
 Contributors are any members of the open source community who participate in project develompent. Contributors may participate on their own behalf or on behalf of their employer. Membership in the [Presto Foundation](https://prestodb.io) is not required in order to contribute, although contributors must have signed a CLA prior to their code being merged (see below).
 
-#### Committers
+### Committers
 
 Committers are members of the contributor community who have demonstrated an ongoing commitment to the health and sustainability of the Presto project through good citizenship and wise stewardship. These individuals have been elevated to a decision-making role, and responsible for reviewing and merging code from contributors. They may also be involved in the release process or other critical project roles.
 
-* [Current list of Presto committers](https://github.com/prestodb/presto/wiki/committers)
+The path to committership starts with becoming a contributor to the project. Over time contributors prove that they have high commitment to the project and they get nominated by an existing committer to become a committer.
+
+When a committer candidate is nominated by an existing committer lazy consensus is required (no vetoes) from existing committers. The nomination should include a justification of why that person should become a committer (e.g., code/test/doc contributions, other positive impact to the project & community, etc.).
+
+Committer candidates:
+
+* Demonstrate good collaboration skills
+* Submit high quality pull requests that conform to Presto coding styles and best practices.
+* Demonstrate good understanding of Presto’s criteria for accepting pull requests
+* Help with reviewing pull requests from the community
+* Contribute to design/technical discussions on Github and Slack
+* Help with user issues on Github, user mailing list, and Slack
+have good judgement around when some code should be merged, or when to ask someone else to make that judgement
+* Care deeply about code quality
+* Care deeply about good test coverage & proper user documentation
+* Care deeply about performance and reliability
+
+Committership can be revoked under rare circumstances, such as when a committer stops becoming a good citizen of the project or when a committer becomes inactive for an extended period of time.
+
+Additional committer positions may be added or existing positions removed by 2/3 approval of the TSC.
 
 ## Things to do prior to contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,9 @@ Current Presto committers:
 | Shixuan Fan       |[shixuan-fan](https://github.com/shixuan-fan)      | Facebook    |
 | Jiexi Lin         |[jessesleeping](https://github.com/jessesleeping)  | Facebook    |
 
+The path to committership starts with becoming a contributor to the project. Over time, contributors can prove that they have high commitment to the project.  Top contributors may become committers through either a simple majority vote by the existing committers, or by a 2/3 vote of the TSC.  An existing committer may be removed in the same manner.
 
-The path to committership starts with becoming a contributor to the project. Over time contributors prove that they have high commitment to the project and they get nominated by an existing committer to become a committer.
-
-When a committer candidate is nominated by an existing committer lazy consensus is required (no vetoes) from existing committers. The nomination should include a justification of why that person should become a committer (e.g., code/test/doc contributions, other positive impact to the project & community, etc.).
+Each potential committer should be nominated prior to the vote.  The nomination should include a justification of why that person should become a committer (e.g., code/test/doc contributions, other positive impact to the project & community, etc.).
 
 Committer candidates:
 
@@ -53,8 +52,6 @@ have good judgement around when some code should be merged, or when to ask someo
 * Care deeply about performance and reliability
 
 Committership can be revoked under rare circumstances, such as when a committer stops becoming a good citizen of the project or when a committer becomes inactive for an extended period of time.
-
-Additional committer positions may be added or existing positions removed by 2/3 approval of the TSC.
 
 ## Things to do prior to contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Committer candidates:
 * Help with reviewing pull requests from the community
 * Contribute to design/technical discussions on Github and Slack
 * Help with user issues on Github, user mailing list, and Slack
-have good judgement around when some code should be merged, or when to ask someone else to make that judgement
+* Have good judgement around when some code should be merged, or when to ask someone else to make that judgement
 * Care deeply about code quality
 * Care deeply about good test coverage & proper user documentation
 * Care deeply about performance and reliability

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Presto
+
+Presto is an Apache 2.0-licensed open source distributed SQL query engine for running interactive analytic queries against data sources of all sizes, ranging from gigabytes to petabytes.
+
+Presto was designed and written from the ground up for interactive analytics and approaches the speed of commercial data warehouses while scaling to the size of organizations like Facebook.
+
+The community owned and driven Presto project is supported by the [Presto Foundation](https://prestodb.io), an independent nonprofit organization with open and neutral governance, hosted under the [Linux Foundation](https://linuxfoundation.org). Learn more about the [Presto Foundation](https://prestodb.io) here.
+
+All Presto development occurs on [GitHub](https://github.com/prestodb), following open source best practices.
+
+## Technical governance
+
+Presto follows industry best practices, with the technical project and its governance distinctly separate from the Presto Foundation. The [Technical Charter](https://github.com/prestodb/tsc/blob/master/CHARTER.md) establishes the Presto Technical Steering Committee as the body which oversees all technical aspects of the open source project. By contrast, the [Presto Foundation](https://prestodb.io) Governing Board is responsible for raising and distributing funds to support project activities, and setting policy. While the two groups are separate, they work in close coordination to establish, guide, and support activities that lead to a long-term, sustainable future for Presto.
+
+### Project roles and responsibilities
+
+#### Contributors
+
+Contributors are any members of the open source community who participate in project develompent. Contributors may participate on their own behalf or on behalf of their employer. Membership in the [Presto Foundation](https://prestodb.io) is not required in order to contribute, although contributors must have signed a CLA prior to their code being merged (see below).
+
+#### Committers
+
+Committers are members of the contributor community who have demonstrated an ongoing commitment to the health and sustainability of the Presto project through good citizenship and wise stewardship. These individuals have been elevated to a decision-making role, and responsible for reviewing and merging code from contributors. They may also be involved in the release process or other critical project roles.
+
+* [Current list of Presto committers](https://github.com/prestodb/presto/wiki/committers)
+
+## Things to do prior to contributing
+
+#### Ensure your contribution complies with the Presto IP Policy
+
+Per section 8 of the [Technical Charter](https://github.com/prestodb/tsc/blob/master/CHARTER.md), all inbound code contributions must be made using the [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0). All documentation must be contributed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+Please review the Technical Charter to ensure you understand the requirements of the open source project. If you have questions, please [file an issue](https://github.com/prestodb/tsc/issues).
+
+#### Sign the CLA
+
+Presto requires contributors to sign a CLA prior to contributing code. The only way to do this is to submit a pull request. The EasyCLA tool will check whether you have signed a CLA previously. If you haven't, it will notify you and present a link to the signing platform.
+
+If you are contributing on behalf of yourself only, you can sign the individual CLA. If you are contributing on behalf of your employer, you can request to be added to your employer's corporate CLA.
+
+## Code of Conduct
+
+The TSC will formally adopt a Code of Conduct as one of the first orders of business.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ Contributors are any members of the open source community who participate in pro
 
 Committers are members of the contributor community who have demonstrated an ongoing commitment to the health and sustainability of the Presto project through good citizenship and wise stewardship. These individuals have been elevated to a decision-making role, and responsible for reviewing and merging code from contributors. They may also be involved in the release process or other critical project roles.
 
+Current Presto committers:
+
+| Name              | Github                                            | Affiliation |
+| ----------------- | ------------------------------------------------- | ------------|
+| Masha Basmanova   |[mbasmanova](https://github.com/mbasmanova)        | Facebook    |
+| Zhenxiao Luo      |[zhenxiao](https://github.com/zhenxiao)            | Twitter     |
+| Andrii Rosa       |[arhimondr](https://github.com/arhimondr)          | Facebook    |
+| Rebecca Schlussel |[rschlussel](https://.github.com/rschlussel)       | Facebook    |
+| James Sun         |[highker](https://github.com/highker)              | Facebook    |
+| Wenlei Xie        |[wenleix](https://github.com/wenleix)              | Facebook    |
+| Rongrong Zhong    |[rongrong](https://github.com/rongrong)            | Facebook    |
+| Shixuan Fan       |[shixuan-fan](https://github.com/shixuan-fan)      | Facebook    |
+| Jiexi Lin         |[jessesleeping](https://github.com/jessesleeping)  | Facebook    |
+
+
 The path to committership starts with becoming a contributor to the project. Over time contributors prove that they have high commitment to the project and they get nominated by an existing committer to become a committer.
 
 When a committer candidate is nominated by an existing committer lazy consensus is required (no vetoes) from existing committers. The nomination should include a justification of why that person should become a committer (e.g., code/test/doc contributions, other positive impact to the project & community, etc.).


### PR DESCRIPTION
This is the initial commit of a default CONTRIBUTING.md file, which will
replicate across all repositories which do not currently have a local
CONTRIBUTING.md.

This PR should be approved by the TSC prior to being merged.

Signed-off-by: Brian Warner <brian@bdwarner.com>